### PR TITLE
Fix situation with hosts file line endings

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -75,7 +75,7 @@ module VagrantPlugins
           file = Pathname.new(file)
           old_file_content = file.read
           new_file_content = update_content(old_file_content, resolving_machine, include_id)
-          file.open('w') { |io| io.write(new_file_content) }
+          file.open('wb') { |io| io.write(new_file_content) }
           old_file_content != new_file_content
         end
 


### PR DESCRIPTION
I ran into a situation in which the the hosts file in the guest (ubuntu 14.04) had CRLF line endings when vagranted from a Windows server 2012 R2, with Vagrant 1.7.2 with hostmanager 1.5.0 . The vagrant commands where run from a cygwin shell.
As per Ruby documentation, replacing open mode to binary "Suppresses EOL <-> CRLF conversion on Windows."